### PR TITLE
fix internal and external cabinet scrolling

### DIFF
--- a/src/components/public-pages/Membership.jsx
+++ b/src/components/public-pages/Membership.jsx
@@ -34,13 +34,10 @@ const Membership = () => (
     {peopleByCategory.map((category, index, array) => (
       <section
         key={category.title}
-        className={`category-container ${
-          index === array.length - 1
-            ? "last-category "
-            : "" + index == 0
-            ? "first-category"
-            : ""
-        }`}
+        className={`category-container
+          ${index === 0 ? " first-category" : ""}
+          ${index === array.length - 1 ? " last-category" : ""}
+        `}
       >
         <h2>{category.title}</h2>
         <div className="people-container">

--- a/src/index.css
+++ b/src/index.css
@@ -131,11 +131,12 @@ a {
   }
 
   .person-name {
-    font-size: 0.9rem;
+    font-size: 1.6rem;
   }
 
   .person-major {
-    font-size: 0.5rem;
+    font-size: 0.9rem;
+    font-weight: 500;
   }
 
   .membership-content {
@@ -144,11 +145,11 @@ a {
   }
 
   .person-info-bottom {
-    height: 3rem;
+    height: 4rem;
   }
 
   .person-position {
-    font-size: 0.7rem;
+    font-size: 1.2rem;
   }
 
   .person-info-top {
@@ -164,6 +165,7 @@ a {
   .service-content {
     width: 92vw !important;
   }
+
   .service-logo {
     position: relative;
     width: 50% !important;

--- a/src/styles/membership.css
+++ b/src/styles/membership.css
@@ -145,3 +145,9 @@ h2 {
   margin-top: 1em;
   padding: 0em 3em 0.5em 3em;
 }
+
+@media (max-width: 768px) {
+  .category-container .people-container {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
executive officers had 1x1 grid scrolling and internal/external did not

simple code change so we have consistent 1x1 grid scrolling for all officers. see example below

<img width="281" height="623" alt="Screenshot 2025-11-19 at 1 16 25 PM" src="https://github.com/user-attachments/assets/05763499-f60f-45ce-9edc-83f5df4d1a8c" />
